### PR TITLE
💄  [#3081] Add new fieldset component for input groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-inwoner/design-tokens",
-  "version": "0.0.8-alpha.1",
+  "version": "0.0.9-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-inwoner/design-tokens",
-      "version": "0.0.8-alpha.1",
+      "version": "0.0.9-alpha.0",
       "license": "EUPL-1.2",
       "devDependencies": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-inwoner/design-tokens",
-  "version": "0.0.8-alpha.1",
+  "version": "0.0.9-alpha.0",
   "description": "Design tokens for Open Inwoner",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/brand/openinwoner/color.tokens.json
+++ b/src/brand/openinwoner/color.tokens.json
@@ -89,6 +89,10 @@
         "value": "#4b4b4b",
         "comment": "Blackish foreground color for the (main) user interface."
       },
+      "fg-lighter": {
+        "value": "#676767",
+        "comment": "Blackish foreground color for lighter text elements (eg date)."
+      },
       "fg-muted": {
         "value": "#949494",
         "comment": "Font/foreground color for non-actionable or less-important content."

--- a/src/community/utrecht/fieldset.tokens.json
+++ b/src/community/utrecht/fieldset.tokens.json
@@ -1,0 +1,21 @@
+{
+  "utrecht": {
+    "form-fieldset": {
+      "margin-block-end": {"value": "0"},
+      "margin-block-start": {"value": "0"},
+      "section": {
+        "background-color": {"value": "#FFFFFF"},
+        "color": {"value": "{oip.color.fg-lighter}"}
+      },
+      "legend": {
+        "color": {"value": "{oip.color.fg-lighter}"},
+        "font-family": {"value": "{oip.typography.sans-serif.font-family}"},
+        "font-size": {"value": "{utrecht.paragraph.small.font-size}"},
+        "font-weight": {"value": "normal"},
+        "line-height": {"value": "21px"},
+        "margin-block-end": {"value": "0"},
+        "margin-block-start": {"value": "0"}
+      }
+    }
+  }
+}

--- a/src/components/fieldset-modifiers.tokens.json
+++ b/src/components/fieldset-modifiers.tokens.json
@@ -1,0 +1,20 @@
+{
+  "oip": {
+    "fieldset": {
+      "horizontal": {
+        "display": {
+          "value": "flex"
+        },
+        "flex-direction": {
+          "value": "row"
+        },
+        "gap": {
+          "value": "7px"
+        },
+        "margin-bottom": {
+          "value": "20px"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a Fieldset for accessibility so checkbox groups or radio groups are read correctly,
could be of use for the contact-list for Plans: 

https://github.com/maykinmedia/open-inwoner/pull/1657 

Again we are using Utrecht as the base example: https://nl-design-system.github.io/utrecht/storybook/?path=/docs/css_css-form-fieldset--docs
They put an extra Div around each Fieldset tag, but we do not have such styling.