### PR TITLE
[#2864] Replace notification-red design-token with a more accessible variant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-inwoner/design-tokens",
-  "version": "0.0.9-alpha.0",
+  "version": "0.0.10-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-inwoner/design-tokens",
-      "version": "0.0.9-alpha.0",
+      "version": "0.0.10-alpha.0",
       "license": "EUPL-1.2",
       "devDependencies": {
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-inwoner/design-tokens",
-  "version": "0.0.9-alpha.0",
+  "version": "0.0.10-alpha.0",
   "description": "Design tokens for Open Inwoner",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/brand/openinwoner/color.tokens.json
+++ b/src/brand/openinwoner/color.tokens.json
@@ -114,7 +114,7 @@
         "border": {}
       },
       "red-notification": {
-        "value": "#d94100",
+        "value": "#e50026",
         "comment": "The bright red color for notification badges and texts."
       }
     }


### PR DESCRIPTION
Color change for multiple components where we use a red 'accent', like indicator-dots, notification-borders, home-userfeed text, Profile-delete buttons.
See Taiga: https://taiga.maykinmedia.nl/project/open-inwoner/issue/2864

First version has already been published on NPM: https://www.npmjs.com/package/@open-inwoner/design-tokens?activeTab=versions

This generates the CSS necessary for use with this PR for (OIP release 1.29 : 
https://github.com/maykinmedia/open-inwoner/pull/1709