### PR TITLE
PP-324 Replace all margin shorthands with margin-block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-inwoner/design-tokens",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-inwoner/design-tokens",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "license": "EUPL-1.2",
       "devDependencies": {
         "chokidar": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-inwoner/design-tokens",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "Design tokens for Open Inwoner",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/components/fieldset-modifiers.tokens.json
+++ b/src/components/fieldset-modifiers.tokens.json
@@ -11,7 +11,7 @@
         "gap": {
           "value": "7px"
         },
-        "margin-bottom": {
+        "margin-block-end": {
           "value": "20px"
         }
       }

--- a/src/components/paragraph-modifiers.tokens.json
+++ b/src/components/paragraph-modifiers.tokens.json
@@ -10,8 +10,8 @@
       },
       "compact": {
         "comment": "TODO: modifier may be removed in future, or added to the shadow DOM.",
-        "margin-bottom": {"value": "0 !important"},
-        "margin-top": {"value": "0 !important"}
+        "margin-block-end": {"value": "0 !important"},
+        "margin-block-start": {"value": "0 !important"}
       }
     },
     "nl-paragraph": {


### PR DESCRIPTION
## Summary

replace all margin shorthand and margin-top/margin-bottom with `margin-block-...` for proper writing-mode compatibility.

## Issue References

Part of issue https://github.com/maykinmedia/open-inwoner/issues/2203

## Checklist

<!-- Remove if not applicable -->

- [x] Bumped version number in both `package.json` and in `package-lock.json` (can also be done after merge with `npm version ...`)

<!-- After merging: publish the package to NPM by creating/pushing a Tag with exact same version name;
visible in https://www.npmjs.com/package/@open-inwoner/design-tokens?activeTab=versions,
Tag visible in https://github.com/maykinmedia/open-inwoner-design-tokens/tags -->
