### PR TITLE
issue #2417: KVKbranch-selector block display token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-inwoner/design-tokens",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-inwoner/design-tokens",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "license": "EUPL-1.2",
       "devDependencies": {
         "chokidar": "^4.0.3",
@@ -2086,8 +2086,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/url": {
       "version": "0.11.4",
@@ -3612,8 +3611,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "url": {
       "version": "0.11.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-inwoner/design-tokens",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Design tokens for Open Inwoner",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/components/combobox.tokens.json
+++ b/src/components/combobox.tokens.json
@@ -5,7 +5,7 @@
       "border-radius": {"value": "3px"},
       "border-style": {"value": "solid"},
       "border-width": {"value": "1px"},
-      "display": {"value": "inline-block"},
+      "display": {"value": "block"},
       "inline-size": {"value": "100%"},
       "font-family": {"value": "{oip.typography.sans-serif.font-family}"},
       "font-size": {"value": "{oip.text.font-size}"},


### PR DESCRIPTION
## Summary

On wide screens (for example in open-inwoner Storybook: https://maykinmedia.github.io/open-inwoner/?path=/story/components-kvkbranchselector--default) the combobox input should break to a new line.
The open-inwoner combox inherits many styles from Utrecht, which has changed from inline-block to block also: https://nl-design-system.github.io/utrecht/storybook/?path=/docs/css_css-combobox--docs

<img width="1040" height="193" alt="Screenshot 2026-06-02 at 17 19 16" src="https://github.com/user-attachments/assets/3fb33532-c8eb-470d-aea3-4e3d700a0af4" />


## Issue References

Issue not in this repository but in OIP: https://github.com/maykinmedia/open-inwoner/issues/2417

## Checklist

<!-- Remove if not applicable -->

- [x] Bumped version number in both `package.json` and in `package-lock.json` (can also be done after merge with `npm version ...`)

<!-- After merging: publish the package to NPM by creating/pushing a Tag with exact same version name;
visible in https://www.npmjs.com/package/@open-inwoner/design-tokens?activeTab=versions,
Tag visible in https://github.com/maykinmedia/open-inwoner-design-tokens/tags -->
