### PR TITLE
:wrench: ci: include zizmor run in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,21 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   prettier:
     name: Check frontend code formatting with prettier
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci
@@ -38,11 +43,14 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Build artifacts
         run: |
@@ -57,3 +65,18 @@ jobs:
         # Tag name must exactly match the version in package.json (no 'v' prefix allowed)
         if: startsWith(github.ref, 'refs/tags/')
         run: npm publish
+
+  zizmor:
+    name: GitHub Actions Security Analysis with zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
## Summary

expands [this issue ](https://github.com/maykinmedia/open-inwoner-design-tokens/pull/46) 

"... include a zizmor run in the CI for this repo? You can re-use https://github.com/maykinmedia/open-inwoner/blob/develop/.github/workflows/code-quality.yml#L130-L144

Especially important here as this leads to a published artifact."