### PR TITLE
fix: [#2747] add extra spacing between Ga Naar arrow and text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-inwoner/design-tokens",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-inwoner/design-tokens",
-      "version": "0.0.32",
+      "version": "0.0.33",
       "license": "EUPL-1.2",
       "devDependencies": {
         "chokidar": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-inwoner/design-tokens",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Design tokens for Open Inwoner",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/components/external-link-plugin.tokens.json
+++ b/src/components/external-link-plugin.tokens.json
@@ -98,7 +98,7 @@
         "margin-block-start": {"value": "0"},
         "margin-block-end": {"value": "0"},
         "margin-inline-start": {
-          "value": "auto",
+          "value": "4px",
           "comment": "Make icon align to the relative end inside a flex-box."
         },
         "margin-inline-end": {"value": "0"},


### PR DESCRIPTION
## Summary

add extra spacing between Ga Naar arrow and text

## Issue References

<!-- Link to related stories/issues: remove if not applicable -->

- Taiga User Story:
- GitHub Issue:

## Checklist

<!-- Remove if not applicable -->

- [x] Bumped version number in both `package.json` and in `package-lock.json` (can also be done after merge with `npm version ...`)

<!-- After merging: publish the package to NPM by creating/pushing a Tag with exact same version name;
visible in https://www.npmjs.com/package/@open-inwoner/design-tokens?activeTab=versions,
Tag visible in https://github.com/maykinmedia/open-inwoner-design-tokens/tags -->
